### PR TITLE
`npm install` to `npm ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Локальный запуск и отладка:
 ```shell
-npm install
+npm ci
 npm run dev
 ```
 


### PR DESCRIPTION
Если делать `npm install`, то он установит пакеты новых версий (если новая версия есть, он её установит)

Команда `npm ci` берёт пакеты и их версии из файла `package-lock.json`. То есть гарантируется установка ровно тех пакетов, которые разработчик использовал при написании приложения

Информация из Интернета:
1. https://www.geeksforgeeks.org/difference-between-npm-i-and-npm-ci-in-node-js/
![image](https://user-images.githubusercontent.com/40500378/203341831-e29c0702-0d89-415b-bac6-2e3b279629bd.png)
1. https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci
![image](https://user-images.githubusercontent.com/40500378/203342047-e8161d0f-6e71-47f8-ac7e-75b82dd701ec.png)

Update:
~~Хотел написать сразу, но забыл~~ Устанавливать пакеты новых версий чревато тем, что могут выпить функции, или убрать поддержку старых, или выкатить непроверенные полностью обновления. Поэтому если обновление пакетов НЕ требуется, лучше писать `npm ci`.
`npm install` должен делать разработчик. Сначала локально проверить, что всё работает, затем уже выкатывать обновления